### PR TITLE
Add test to cover bucketing saving.

### DIFF
--- a/awswrangler/s3/_write_dataset.py
+++ b/awswrangler/s3/_write_dataset.py
@@ -108,7 +108,7 @@ def _get_bucket_number(number_of_buckets: int, values: List[Union[str, int, bool
 
 
 def _get_value_hash(value: Union[str, int, bool]) -> int:
-    if isinstance(value, (int, np.int)):
+    if isinstance(value, (int, np.integer)):
         return int(value)
     if isinstance(value, (str, np.str)):
         value_hash = 0


### PR DESCRIPTION
What do you think about add more tests like this one? The idea is to try to ensure that our tables are really adding some save/gain.

Also, I've faced some issues related with data types, I didn't dig too much but the `np.int` was not capturing my `np.int64` column. Maybe we should cover tests with other "kinds" of intergers like the new `Int64` (Capital i). The same for strings/objects.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
